### PR TITLE
Feat: Implement View Model to Signup Screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,10 +59,13 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    
+
+    // View Model
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+
     //Lottie
     implementation(libs.lottie.compose)
-    
+
     // Tests
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/do55anto5/moviestreaming/core/enums/InputType.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/core/enums/InputType.kt
@@ -1,0 +1,6 @@
+package com.do55anto5.moviestreaming.core.enums
+
+enum class InputType {
+    EMAIL,
+    PASSWORD
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/action/SignupAction.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/action/SignupAction.kt
@@ -1,0 +1,10 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.signup.action
+
+import com.do55anto5.moviestreaming.core.enums.InputType
+
+sealed class SignupAction {
+    data class OnValueChange(
+        val value: String,
+        val type: InputType
+    ) : SignupAction()
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,12 +39,17 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.do55anto5.moviestreaming.R
+import com.do55anto5.moviestreaming.core.enums.InputType
 import com.do55anto5.moviestreaming.presenter.components.button.PrimaryButton
 import com.do55anto5.moviestreaming.presenter.components.button.SocialButton
 import com.do55anto5.moviestreaming.presenter.components.divider.HorizontalDividerWithText
 import com.do55anto5.moviestreaming.presenter.components.editText.TextFieldUI
 import com.do55anto5.moviestreaming.presenter.components.topAppBar.TopAppBarUI
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.action.SignupAction
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.state.SignupState
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.viewmodel.SignupViewModel
 import com.do55anto5.moviestreaming.presenter.theme.MovieStreamingTheme
 import com.do55anto5.moviestreaming.presenter.theme.UrbanistFamily
 
@@ -51,18 +57,24 @@ import com.do55anto5.moviestreaming.presenter.theme.UrbanistFamily
 fun SignupScreen(
     onBackPressed: () -> Unit
 ) {
+
+    val viewModel: SignupViewModel = viewModel()
+    val state = viewModel.state.collectAsState().value
+
     SignupContent(
+        state = state,
+        action = viewModel::submitAction,
         onBackPressed = { }
     )
 }
 
 @Composable
 fun SignupContent(
+    state: SignupState = SignupState(),
+    action: (SignupAction) -> Unit,
     onBackPressed: () -> Unit
 ) {
 
-    var emailValue by remember { mutableStateOf("") }
-    var passwordValue by remember { mutableStateOf("") }
     var showPassword by remember { mutableStateOf(false) }
 
     Scaffold(
@@ -107,7 +119,7 @@ fun SignupContent(
                     // EMAIL INPUT FIELD
                     TextFieldUI(
                         modifier = Modifier,
-                        value = emailValue,
+                        value = state.email,
                         label = stringResource(R.string.label_input_email_signup_screen),
                         placeholder = stringResource(R.string.placeholder_input_email_signup_screen),
                         mLeadingIcon = {
@@ -121,7 +133,12 @@ fun SignupContent(
                             keyboardType = KeyboardType.Email
                         ),
                         onValueChange = {
-                            emailValue = it
+                            action(
+                                SignupAction.OnValueChange(
+                                    value = it,
+                                    type = InputType.EMAIL
+                                )
+                            )
                         }
                     )
 
@@ -130,16 +147,16 @@ fun SignupContent(
                     // PASSWORD INPUT FIELD
                     TextFieldUI(
                         modifier = Modifier,
-                        value = passwordValue,
+                        value = state.password,
                         label = stringResource(R.string.label_input_password_signup_screen),
                         placeholder = stringResource(R.string.placeholder_input_password_signup_screen),
                         // PASSWORD MASK
                         visualTransformation =
-                            if (showPassword) {
-                                VisualTransformation.None
-                            } else {
-                                PasswordVisualTransformation()
-                            },
+                        if (showPassword) {
+                            VisualTransformation.None
+                        } else {
+                            PasswordVisualTransformation()
+                        },
                         mLeadingIcon = {
                             Icon(
                                 painter = painterResource(R.drawable.ic_password),
@@ -148,12 +165,12 @@ fun SignupContent(
                             )
                         },
                         mTrailingIcon = {
-                            IconButton(
-                                onClick = {
-                                    showPassword = !showPassword
-                                },
-                                content = {
-                                    if (passwordValue.isNotEmpty()) {
+                            if (state.password.isNotEmpty()) {
+                                IconButton(
+                                    onClick = {
+                                        showPassword = !showPassword
+                                    },
+                                    content = {
                                         Icon(
                                             painter =
                                             if (showPassword) {
@@ -164,14 +181,19 @@ fun SignupContent(
                                             contentDescription = null,
                                         )
                                     }
-                                }
-                            )
+                                )
+                            }
                         },
                         keyboardOptions = KeyboardOptions(
                             keyboardType = KeyboardType.Email
                         ),
                         onValueChange = {
-                            passwordValue = it
+                            action(
+                                SignupAction.OnValueChange(
+                                    value = it,
+                                    type = InputType.PASSWORD
+                                )
+                            )
                         }
                     )
 
@@ -265,6 +287,11 @@ fun SignupContent(
 @Composable
 private fun SignupScreenPreview() {
     MovieStreamingTheme {
-        SignupContent(onBackPressed = {})
+
+        SignupContent(
+            state = SignupState(),
+            action = {},
+            onBackPressed = {}
+        )
     }
 }

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/state/SignupState.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/state/SignupState.kt
@@ -1,0 +1,7 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.signup.state
+
+data class SignupState(
+    val email: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false
+)

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
@@ -1,0 +1,48 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.signup.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.do55anto5.moviestreaming.core.enums.InputType
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.action.SignupAction
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.state.SignupState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class SignupViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(SignupState())
+    val state = _state.asStateFlow()
+
+    fun submitAction(action: SignupAction) {
+        when (action) {
+            is SignupAction.OnValueChange -> {
+                onValueChange(action.value, action.type)
+            }
+        }
+    }
+
+    private fun onValueChange(value: String, type: InputType) {
+        when (type) {
+            InputType.EMAIL -> {
+                onEmailChange(value)
+            }
+
+            InputType.PASSWORD -> {
+                onPasswordChange(value)
+            }
+        }
+    }
+
+
+    private fun onEmailChange(value: String) {
+        _state.update { currentState ->
+            currentState.copy(email = value)
+        }
+    }
+
+    private fun onPasswordChange(value: String) {
+        _state.update { currentState ->
+            currentState.copy(password = value)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,10 +8,12 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.4"
 activityCompose = "1.9.1"
 composeBom = "2024.08.00"
+lifecycleViewmodelCompose = "2.8.4"
 lottie-compose= "6.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
### This PR implements a ViewModel on the Signup screen to manage state and actions more efficiently.

### **Main changes:**
#### - Creation of a ViewModel (SignupViewModel) to handle screen state and actions.
#### - Implementation of an enum class (InputType) to define action types and adapt screen behavior accordingly.
#### - Creation of a state (SignUpState) to represent the state of text fields on the Signup screen.
#### - Decoupling of state handling logic from SignupScreen to ViewModel.