### PR TITLE
Implement RegisterUseCase and Dependency Injection for ViewModel

### DIFF
--- a/app/src/main/java/com/do55anto5/moviestreaming/core/activity/application/MainApplication.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/core/activity/application/MainApplication.kt
@@ -1,19 +1,25 @@
 package com.do55anto5.moviestreaming.core.activity.application
 
 import android.app.Application
+import com.do55anto5.moviestreaming.di.presenterModule
 import com.do55anto5.moviestreaming.di.repositoryModule
+import com.do55anto5.moviestreaming.di.useCaseModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
-class MainApplication: Application() {
+class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
         startKoin {
             androidLogger()
             androidContext(this@MainApplication)
-            modules(repositoryModule)
+            modules(
+                repositoryModule,
+                useCaseModule,
+                presenterModule
+            )
         }
     }
 }

--- a/app/src/main/java/com/do55anto5/moviestreaming/di/PresenterModule.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/di/PresenterModule.kt
@@ -1,0 +1,11 @@
+package com.do55anto5.moviestreaming.di
+
+import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.viewmodel.SignupViewModel
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val presenterModule = module {
+
+    viewModel { SignupViewModel(registerUseCase = get()) }
+
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/di/UseCaseModule.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/di/UseCaseModule.kt
@@ -1,0 +1,10 @@
+package com.do55anto5.moviestreaming.di
+
+import com.do55anto5.moviestreaming.domain.remote.usecase.authentication.RegisterUseCase
+import org.koin.dsl.module
+
+val useCaseModule = module {
+
+    factory { RegisterUseCase(repository = get()) }
+
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/domain/remote/usecase/authentication/RegisterUseCase.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/domain/remote/usecase/authentication/RegisterUseCase.kt
@@ -1,0 +1,13 @@
+package com.do55anto5.moviestreaming.domain.remote.usecase.authentication
+
+import com.do55anto5.moviestreaming.domain.remote.repository.authentication.SignupRepository
+
+class RegisterUseCase(
+    private val repository: SignupRepository
+) {
+
+    suspend operator fun invoke(email: String, password: String) {
+        repository.register(email, password)
+    }
+
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.do55anto5.moviestreaming.R
 import com.do55anto5.moviestreaming.core.enums.InputType
 import com.do55anto5.moviestreaming.presenter.components.button.PrimaryButton
@@ -49,13 +48,14 @@ import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.stat
 import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.viewmodel.SignupViewModel
 import com.do55anto5.moviestreaming.presenter.theme.MovieStreamingTheme
 import com.do55anto5.moviestreaming.presenter.theme.UrbanistFamily
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SignupScreen(
     onBackPressed: () -> Unit
 ) {
 
-    val viewModel: SignupViewModel = viewModel()
+    val viewModel = koinViewModel<SignupViewModel>()
     val state = viewModel.state.collectAsState().value
 
     SignupContent(

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
@@ -3,13 +3,16 @@ package com.do55anto5.moviestreaming.presenter.screens.authentication.signup.vie
 import androidx.lifecycle.ViewModel
 import com.do55anto5.moviestreaming.core.enums.InputType
 import com.do55anto5.moviestreaming.core.functions.isValidEmail
+import com.do55anto5.moviestreaming.domain.remote.usecase.authentication.RegisterUseCase
 import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.action.SignupAction
 import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.state.SignupState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
-class SignupViewModel : ViewModel() {
+class SignupViewModel(
+    private val registerUseCase: RegisterUseCase
+) : ViewModel() {
 
     private val _state = MutableStateFlow(SignupState())
     val state = _state.asStateFlow()


### PR DESCRIPTION
### This PR introduces the `RegisterUseCase` and sets up dependency injection for the `SignupViewModel` using Koin.

* **Added `RegisterUseCase`:** This use case encapsulates the logic for user registration.
* **Updated `SignupViewModel`:** The `SignupViewModel` now expects an instance of `RegisterUseCase` in its constructor.
* **Created `useCaseModule`:** This Koin module defines a factory for `RegisterUseCase`, injecting the necessary repository dependency.
* **Created `presenterModule`:** This Koin module defines a factory for `SignupViewModel`, injecting the `RegisterUseCase` dependency.
* **Integrated modules into `MainApplication`:** Added the `useCaseModule` and `presenterModule` to the Koin setup in `MainApplication`.
* **Refactored to use `koinViewModel`:** Updated the instantiation of `SignupViewModel` to use `koinViewModel`, enabling easier testing with dependency injection.