### PR TITLE
Feat: Implement Login Screen with ViewModel and State Management

### DIFF
--- a/app/src/main/java/com/do55anto5/moviestreaming/di/PresenterModule.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/di/PresenterModule.kt
@@ -1,5 +1,6 @@
 package com.do55anto5.moviestreaming.di
 
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.viewmodel.LoginViewModel
 import com.do55anto5.moviestreaming.presenter.screens.authentication.signup.viewmodel.SignupViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -11,6 +12,10 @@ val presenterModule = module {
             registerUseCase = get(),
             saveUserUseCase = get()
         )
+    }
+
+    viewModel {
+        LoginViewModel()
     }
 
 }

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/action/LoginAction.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/action/LoginAction.kt
@@ -1,0 +1,17 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.login.action
+
+import com.do55anto5.moviestreaming.core.enums.input.InputType
+
+sealed class LoginAction {
+
+    data class OnValueChange(
+        val value: String,
+        val type: InputType
+    ) : LoginAction()
+
+    data object OnPasswordVisibilityChange: LoginAction()
+
+    data object OnSignIn: LoginAction()
+
+    data object ResetErrorState: LoginAction()
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/screen/LoginScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/screen/LoginScreen.kt
@@ -1,0 +1,354 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.login.screen
+
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.do55anto5.moviestreaming.R
+import com.do55anto5.moviestreaming.core.enums.input.InputType
+import com.do55anto5.moviestreaming.presenter.components.button.PrimaryButton
+import com.do55anto5.moviestreaming.presenter.components.button.SocialButton
+import com.do55anto5.moviestreaming.presenter.components.divider.HorizontalDividerWithText
+import com.do55anto5.moviestreaming.presenter.components.editText.TextFieldUI
+import com.do55anto5.moviestreaming.presenter.components.snackbar.FeedbackUI
+import com.do55anto5.moviestreaming.presenter.components.topAppBar.TopAppBarUI
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.action.LoginAction
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.state.LoginState
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.viewmodel.LoginViewModel
+import com.do55anto5.moviestreaming.presenter.theme.MovieStreamingTheme
+import com.do55anto5.moviestreaming.presenter.theme.UrbanistFamily
+import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun LoginScreen(
+                onBackPressed: () -> Unit
+) {
+
+    val viewModel = koinViewModel<LoginViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    LoginContent(
+        state = state,
+        action = viewModel::submitAction,
+        onBackPressed = { }
+    )
+}
+
+@Composable
+fun LoginContent(
+    state: LoginState = LoginState(),
+    action: (LoginAction) -> Unit,
+    onBackPressed: () -> Unit
+) {
+
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(state.hasError) {
+        if (state.hasError) {
+            scope.launch {
+                val result = snackbarHostState
+                    .showSnackbar(
+                        message = context.getString(
+                            state.feedbackUI?.second ?: R.string.error_generic
+                        )
+                    )
+
+                if (result == SnackbarResult.Dismissed) {
+                    action(LoginAction.ResetErrorState)
+                }
+
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBarUI(
+                onClick = {}
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { snackbarData ->
+                    state.feedbackUI?.let { feedbackUI ->
+                        FeedbackUI(
+                            message = snackbarData.visuals.message,
+                            type = feedbackUI.first
+                        )
+                    }
+                }
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MovieStreamingTheme.colorScheme.backgroundColor)
+                    .verticalScroll(rememberScrollState())
+                    .padding(paddingValues)
+                    .padding(horizontal = 24.dp, vertical = 48.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                content = {
+                    Image(
+                        painter = painterResource(id = R.drawable.logo),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(120.dp)
+                    )
+
+                    Spacer(Modifier.height(48.dp))
+
+                    Text(
+                        text = stringResource(R.string.label_title_login_screen),
+                        style = TextStyle(
+                            fontSize = 32.sp,
+                            lineHeight = 38.4.sp,
+                            fontFamily = UrbanistFamily,
+                            fontWeight = FontWeight.Bold,
+                            color = MovieStreamingTheme.colorScheme.textColor,
+                            textAlign = TextAlign.Center
+                        )
+                    )
+
+                    Spacer(Modifier.height(48.dp))
+
+                    // EMAIL INPUT FIELD
+                    TextFieldUI(
+                        modifier = Modifier,
+                        value = state.email,
+                        label = stringResource(R.string.label_input_email_login_screen),
+                        placeholder = stringResource(R.string.placeholder_input_email_login_screen),
+                        mLeadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_email_fill),
+                                contentDescription = null,
+                                tint = MovieStreamingTheme.colorScheme.greyscale500Color
+                            )
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Email,
+                            imeAction = ImeAction.Next
+                        ),
+                        onValueChange = {
+                            action(
+                                LoginAction.OnValueChange(
+                                    value = it,
+                                    type = InputType.EMAIL
+                                )
+                            )
+                        }
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    // PASSWORD INPUT FIELD
+                    TextFieldUI(
+                        modifier = Modifier,
+                        value = state.password,
+                        label = stringResource(R.string.label_input_password_login_screen),
+                        placeholder = stringResource(R.string.placeholder_input_password_login_screen),
+                        // PASSWORD MASK
+                        visualTransformation =
+                        if (state.passwordVisibility) {
+                            VisualTransformation.None
+                        } else {
+                            PasswordVisualTransformation()
+                        },
+                        mLeadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_password_mine),
+                                contentDescription = null,
+                                tint = MovieStreamingTheme.colorScheme.greyscale500Color
+                            )
+                        },
+                        mTrailingIcon = {
+                            if (state.password.isNotEmpty()) {
+                                IconButton(
+                                    onClick = {
+                                        action(LoginAction.OnPasswordVisibilityChange)
+                                    },
+                                    content = {
+                                        Icon(
+                                            painter =
+                                            if (state.passwordVisibility) {
+                                                painterResource(R.drawable.ic_hide)
+                                            } else {
+                                                painterResource(R.drawable.ic_show)
+                                            },
+                                            contentDescription = null,
+                                        )
+                                    }
+                                )
+                            }
+                        },
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Email,
+                            imeAction = ImeAction.Done
+                        ),
+                        onValueChange = {
+                            action(
+                                LoginAction.OnValueChange(
+                                    value = it,
+                                    type = InputType.PASSWORD
+                                )
+                            )
+                        }
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    PrimaryButton(
+                        text = stringResource(R.string.label_button_login_screen),
+                        isLoading = false,
+                        enabled = state.enableSignInButton,
+                        onClick = { action(LoginAction.OnSignIn) }
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    Text(
+                        text = stringResource(R.string.label_forgot_password_login_screen),
+                        style = TextStyle(
+                            fontSize = 16.sp,
+                            lineHeight = 22.4.sp,
+                            fontFamily = UrbanistFamily,
+                            fontWeight = FontWeight.Bold,
+                            color = MovieStreamingTheme.colorScheme.defaultColor,
+                            textAlign = TextAlign.Center,
+                            letterSpacing = 0.2.sp
+                        )
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    HorizontalDividerWithText(
+                        text = stringResource(R.string.label_or_login_screen)
+                    )
+
+                    Spacer(Modifier.height(20.dp))
+
+                    // SOCIAL BUTTONS
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.Center,
+                        content = {
+                            SocialButton(
+                                icon = painterResource(id = R.drawable.ic_google),
+                                onClick = {}
+                            )
+
+                            Spacer(modifier = Modifier.width(20.dp))
+
+                            SocialButton(
+                                icon = painterResource(id = R.drawable.ic_facebook),
+                                onClick = {}
+                            )
+
+                            Spacer(modifier = Modifier.width(20.dp))
+
+                            SocialButton(
+                                icon = painterResource(id = R.drawable.ic_github),
+                                onClick = {}
+                            )
+                        }
+                    )
+
+                    Spacer(Modifier.height(24.dp))
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        content = {
+                            Text(
+                                text = stringResource(id = R.string.label_sign_up_account_login_screen),
+                                style = TextStyle(
+                                    fontSize = 14.sp,
+                                    lineHeight = 19.6.sp,
+                                    fontFamily = UrbanistFamily,
+                                    color = MovieStreamingTheme.colorScheme.textColor,
+                                    textAlign = TextAlign.Right,
+                                    letterSpacing = 0.2.sp
+                                )
+                            )
+
+                            Spacer(modifier = Modifier.width(8.dp))
+
+                            Text(
+                                text = stringResource(id = R.string.label_sign_up_login_screen),
+                                style = TextStyle(
+                                    fontSize = 14.sp,
+                                    lineHeight = 19.6.sp,
+                                    fontFamily = UrbanistFamily,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MovieStreamingTheme.colorScheme.defaultColor,
+                                    textAlign = TextAlign.Right,
+                                    letterSpacing = 0.2.sp
+                                )
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun LoginScreenPreview() {
+    MovieStreamingTheme {
+
+        LoginContent(
+            state = LoginState(),
+            action = {},
+            onBackPressed = {}
+        )
+    }
+}

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/state/LoginState.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/state/LoginState.kt
@@ -1,0 +1,13 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.login.state
+
+import com.do55anto5.moviestreaming.core.enums.feedback.FeedbackType
+
+data class LoginState(
+    val isLoading: Boolean = false,
+    val email: String = "",
+    val password: String = "",
+    val passwordVisibility: Boolean = false,
+    val enableSignInButton: Boolean = false,
+    val hasError: Boolean = false,
+    val feedbackUI: Pair<FeedbackType, Int>? = null
+)

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/viewmodel/LoginViewModel.kt
@@ -1,0 +1,111 @@
+package com.do55anto5.moviestreaming.presenter.screens.authentication.login.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.do55anto5.moviestreaming.core.enums.feedback.FeedbackType
+import com.do55anto5.moviestreaming.core.enums.input.InputType
+import com.do55anto5.moviestreaming.core.functions.isValidEmail
+import com.do55anto5.moviestreaming.core.helper.FirebaseHelper
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.action.LoginAction
+import com.do55anto5.moviestreaming.presenter.screens.authentication.login.state.LoginState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LoginViewModel() : ViewModel() {
+
+    private val _state = MutableStateFlow(LoginState())
+    val state = _state.asStateFlow()
+
+    fun submitAction(action: LoginAction) {
+        when (action) {
+            is LoginAction.OnValueChange -> {
+                onValueChange(action.value, action.type)
+            }
+
+            is LoginAction.OnPasswordVisibilityChange -> {
+                onPasswordVisibilityChange()
+            }
+
+            is LoginAction.OnSignIn -> {
+                onSignIn()
+            }
+
+            is LoginAction.ResetErrorState -> {
+                resetErrorState()
+            }
+        }
+    }
+
+    private fun onSignIn() {
+        viewModelScope.launch {
+            try {
+
+            } catch (exception: Exception) {
+                exception.printStackTrace()
+
+                _state.update { currentState ->
+                    currentState.copy(
+                        hasError = true,
+                        feedbackUI = Pair(
+                            FeedbackType.ERROR,
+                            FirebaseHelper.validateError(exception.message)
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun onValueChange(value: String, type: InputType) {
+        when (type) {
+            InputType.EMAIL -> {
+                onEmailChange(value)
+            }
+
+            InputType.PASSWORD -> {
+                onPasswordChange(value)
+            }
+        }
+
+        enableSignInButton()
+    }
+
+    private fun onEmailChange(value: String) {
+        _state.update { currentState ->
+            currentState.copy(email = value)
+        }
+    }
+
+    private fun onPasswordChange(value: String) {
+        _state.update { currentState ->
+            currentState.copy(password = value)
+        }
+    }
+
+    private fun onPasswordVisibilityChange() {
+        _state.update { currentState ->
+            currentState.copy(passwordVisibility = !currentState.passwordVisibility)
+        }
+    }
+
+    private fun enableSignInButton() {
+        val emailValid = isValidEmail(_state.value.email)
+        val passwordValid = _state.value.password.isNotBlank()
+
+        _state.update { currentState ->
+            currentState.copy(enableSignInButton = emailValid && passwordValid)
+        }
+    }
+
+    private fun resetErrorState() {
+        _state.update { currentState ->
+            currentState.copy(
+                hasError = false,
+                feedbackUI = null
+            )
+        }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,4 +40,16 @@
     <string name="label_sign_up_question_signup_screen">Já tem uma conta?</string>
     <string name="label_sign_in_signup_screen">Entrar</string>
 
+    <!--    LoginScreen-->
+    <string name="label_title_login_screen">Login no seu Perfil</string>
+    <string name="placeholder_input_email_login_screen">Insira seu email</string>
+    <string name="placeholder_input_password_login_screen">Insira sua senha</string>
+    <string name="label_input_email_login_screen">Email</string>
+    <string name="label_input_password_login_screen">Senha</string>
+    <string name="label_button_login_screen">Entrar</string>
+    <string name="label_forgot_password_login_screen">Esqueceu a senha?</string>
+    <string name="label_or_login_screen">ou continue com</string>
+    <string name="label_sign_up_account_login_screen">Não tem uma conta?</string>
+    <string name="label_sign_up_login_screen">Criar conta</string>
+
 </resources>


### PR DESCRIPTION
### This PR introduces the Login screen to the app, complete with its own ViewModel and state management using `LoginState` and `LoginAction`.

* **Added `LoginScreen` composable:** Created the UI for the login screen, including input fields for email and password, a login button, and error handling.
* **Implemented `LoginViewModel`:** Created a ViewModel to handle the login logic and manage the screen's state.
* **Defined `LoginState` and `LoginAction`:** Introduced data classes to represent the screen's state and possible actions, enabling predictable state management.
* **Injected `LoginViewModel` in `presenterModule`:** Made the `LoginViewModel` available for dependency injection using Hilt.
* **Updated `strings.xml`:** Added string values for the login screen, ensuring proper localization.