### PR TITLE
Feat: Implement User Authentication and improve Navigation Logic

### DIFF
--- a/app/src/main/java/com/do55anto5/moviestreaming/core/helper/FirebaseHelper.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/core/helper/FirebaseHelper.kt
@@ -9,6 +9,8 @@ class FirebaseHelper {
 
         fun getAuth() = FirebaseAuth.getInstance()
 
+        fun isAuthenticated() = getAuth().currentUser != null
+
         fun getDatabase() = FirebaseDatabase.getInstance().reference
 
         fun getUserId() = getAuth().currentUser?.uid.orEmpty()

--- a/app/src/main/java/com/do55anto5/moviestreaming/core/navigation/hosts/authentication/AuthenticationNavHost.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/core/navigation/hosts/authentication/AuthenticationNavHost.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.do55anto5.moviestreaming.core.navigation.hosts.app.appNavHost
+import com.do55anto5.moviestreaming.core.navigation.routes.app.AppRoutes
 import com.do55anto5.moviestreaming.core.navigation.routes.authentication.AuthenticationRoutes
 import com.do55anto5.moviestreaming.presenter.screens.authentication.home.screen.HomeAuthenticationScreen
 import com.do55anto5.moviestreaming.presenter.screens.authentication.login.screen.LoginScreen
@@ -34,6 +35,13 @@ fun NavGraphBuilder.authenticationNavHost(navHostController: NavHostController) 
                         }
                     }
                 },
+                navigateToAppScreen = {
+                    navHostController.navigate(AppRoutes.Graph) {
+                        popUpTo(AuthenticationRoutes.Login) {
+                            inclusive = true
+                        }
+                    }
+                },
                 onBackPressed = {
                     navHostController.popBackStack()
                 }
@@ -43,6 +51,13 @@ fun NavGraphBuilder.authenticationNavHost(navHostController: NavHostController) 
             SignupScreen(
                 navigateToLoginScreen = {
                     navHostController.navigate(AuthenticationRoutes.Login) {
+                        popUpTo(AuthenticationRoutes.Signup) {
+                            inclusive = true
+                        }
+                    }
+                },
+                navigateToAppScreen = {
+                    navHostController.navigate(AppRoutes.Graph) {
                         popUpTo(AuthenticationRoutes.Signup) {
                             inclusive = true
                         }

--- a/app/src/main/java/com/do55anto5/moviestreaming/core/navigation/hosts/onboarding/OnboardingNavHost.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/core/navigation/hosts/onboarding/OnboardingNavHost.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.do55anto5.moviestreaming.core.navigation.hosts.app.appNavHost
 import com.do55anto5.moviestreaming.core.navigation.hosts.authentication.authenticationNavHost
+import com.do55anto5.moviestreaming.core.navigation.routes.app.AppRoutes
 import com.do55anto5.moviestreaming.core.navigation.routes.authentication.AuthenticationRoutes
 import com.do55anto5.moviestreaming.core.navigation.routes.onboarding.OnboardingRoutes
 import com.do55anto5.moviestreaming.presenter.screens.splash.screen.SplashScreen
@@ -21,6 +22,13 @@ fun OnboardingNavHost(navHostController: NavHostController) {
             SplashScreen(
                 navigateToWelcomeScreen = {
                     navHostController.navigate(OnboardingRoutes.Welcome) {
+                        popUpTo(OnboardingRoutes.Splash) {
+                            inclusive = true
+                        }
+                    }
+                },
+                navigateToAppScreen = {
+                    navHostController.navigate(AppRoutes.Graph) {
                         popUpTo(OnboardingRoutes.Splash) {
                             inclusive = true
                         }

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/screen/LoginScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/screen/LoginScreen.kt
@@ -64,11 +64,22 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun LoginScreen(
     navigateToSignupScreen: () -> Unit,
+    navigateToAppScreen: () -> Unit,
     onBackPressed: () -> Unit
 ) {
 
     val viewModel = koinViewModel<LoginViewModel>()
     val state by viewModel.state.collectAsState()
+
+    with (state) {
+        LaunchedEffect(isLoading, isAuthenticated) {
+            if (!isLoading) {
+                if(isAuthenticated) {
+                    navigateToAppScreen()
+                }
+            }
+        }
+    }
 
     LoginContent(
         state = state,

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/state/LoginState.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/state/LoginState.kt
@@ -9,5 +9,6 @@ data class LoginState(
     val passwordVisibility: Boolean = false,
     val enableSignInButton: Boolean = false,
     val hasFeedback: Boolean = false,
-    val feedbackUI: Pair<FeedbackType, Int>? = null
+    val feedbackUI: Pair<FeedbackType, Int>? = null,
+    val isAuthenticated: Boolean = false
 )

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/login/viewmodel/LoginViewModel.kt
@@ -48,6 +48,9 @@ class LoginViewModel(
                     email = _state.value.email,
                     password = _state.value.password
                 )
+
+                _state.update { currentState -> currentState.copy(isAuthenticated = true) }
+
             } catch (exception: Exception) {
                 exception.printStackTrace()
 

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/screen/SignupScreen.kt
@@ -64,11 +64,18 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun SignupScreen(
     navigateToLoginScreen: () -> Unit,
+    navigateToAppScreen: () -> Unit,
     onBackPressed: () -> Unit
 ) {
 
     val viewModel = koinViewModel<SignupViewModel>()
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(state.isAuthenticated) {
+        if (state.isAuthenticated) {
+            navigateToAppScreen()
+        }
+    }
 
     SignupContent(
         state = state,

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/state/SignupState.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/state/SignupState.kt
@@ -9,5 +9,6 @@ data class SignupState(
     val passwordVisibility: Boolean = false,
     val enableSignupButton: Boolean = false,
     val hasError: Boolean = false,
-    val feedbackUI: Pair<FeedbackType, Int>? = null
+    val feedbackUI: Pair<FeedbackType, Int>? = null,
+    val isAuthenticated: Boolean = false
 )

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/authentication/signup/viewmodel/SignupViewModel.kt
@@ -52,6 +52,9 @@ class SignupViewModel(
                     password = _state.value.password
                 )
                 saveUserUseCase(user = User(email = _state.value.email))
+
+                _state.update { currentState -> currentState.copy(isAuthenticated = true) }
+
             } catch (exception: Exception) {
                 exception.printStackTrace()
 

--- a/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/splash/screen/SplashScreen.kt
+++ b/app/src/main/java/com/do55anto5/moviestreaming/presenter/screens/splash/screen/SplashScreen.kt
@@ -31,22 +31,26 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun SplashScreen(
     navigateToWelcomeScreen: () -> Unit,
+    navigateToAppScreen: () -> Unit,
     navigateToHomeAuthenticationScreen: () -> Unit
 ) {
     val viewModel = koinViewModel<SplashViewModel>()
     val state by viewModel.state.collectAsState()
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(state.isLoading, state.isWelcomeVisited) {
-        scope.launch {
-            delay(2000)
-            viewModel.submitAction(action = SplashAction.OnNextScreen)
-
-            if (!state.isLoading) {
-                if (state.isWelcomeVisited) {
-                    navigateToHomeAuthenticationScreen()
-                } else {
-                    navigateToWelcomeScreen()
+    with (state) {
+        LaunchedEffect(isLoading, isWelcomeVisited, isAuthenticated) {
+            scope.launch {
+                delay(2000)
+                viewModel.submitAction(action = SplashAction.OnNextScreen)
+                if (!isLoading) {
+                    if(isAuthenticated) {
+                        navigateToAppScreen()
+                    } else if (isWelcomeVisited) {
+                        navigateToHomeAuthenticationScreen()
+                    } else {
+                        navigateToWelcomeScreen()
+                    }
                 }
             }
         }


### PR DESCRIPTION
### This PR introduces functionality to verify user authentication status and navigate to the appropriate screen based on whether the user is logged in or not.

**Changes:**

* Implemented `FirebaseHelper` to check if the user is currently logged in.
* Added `isAuthenticated` state to `LoginState` and `SignupState` to track authentication status.
* Updated `LoginViewModel` and `SignupViewModel` to handle the `isAuthenticated` state, similar to `SplashViewModel`.
* Implemented a consistent `LaunchedEffect` navigation logic in `SplashScreen`, `LoginScreen`, and `SignupScreen`:
    - If the user is authenticated (`isAuthenticated` is true), navigate to `AppScreen`.
* Set up navigation to `AppScreen` in `authenticationNavHost` and `OnboardingNavHost`.

**Testing:**

* [ ] Manually tested the authentication flow, verifying that logged-in users are redirected to `AppScreen`.